### PR TITLE
Remove instructional text from game UI

### DIFF
--- a/public/js/GameUI.js
+++ b/public/js/GameUI.js
@@ -240,7 +240,7 @@ class GameUI {
             if (hasDrawn) {
                 this.currentTurn.textContent = 'Trascina una carta nel pozzo per scartarla';
             } else {
-                this.currentTurn.textContent = 'Trascina una carta dal mazzo o pozzo';
+                this.currentTurn.textContent = 'È il tuo turno';
             }
             this.turnIndicator.classList.add('your-turn');
         } else {


### PR DESCRIPTION
## Summary
- Rimuove il testo istruttivo "Trascina una carta dal mazzo o pozzo" dall'interfaccia
- Sostituito con il messaggio più semplice "È il tuo turno"

Closes #3

## Test plan
- [ ] Avviare il server con `npm start`
- [ ] Entrare in una partita
- [ ] Verificare che durante il proprio turno (prima di pescare) appaia "È il tuo turno"

🤖 Generated with [Claude Code](https://claude.com/claude-code)