### PR TITLE
Arrange players around green table

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -282,27 +282,66 @@ input[type="text"]:focus {
     opacity: 0.5;
 }
 
-/* Video Section */
-.video-section {
-    background: var(--card-bg);
-    padding: 16px;
-    border-bottom: 1px solid rgba(255,255,255,0.1);
+/* Table Container - Players around the table */
+.table-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
 }
 
-.videos-grid {
+.table-middle-row {
     display: flex;
+    align-items: center;
     justify-content: center;
     gap: 16px;
+    width: 100%;
+}
+
+/* Player positions around the table */
+.players-position {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    min-height: 90px;
+}
+
+.players-top {
     flex-wrap: wrap;
 }
 
+.players-left,
+.players-right {
+    flex-direction: column;
+    min-width: 130px;
+}
+
+.players-bottom {
+    margin-top: auto;
+}
+
+/* Video wrapper styling */
 .video-wrapper {
     position: relative;
-    width: 160px;
-    height: 120px;
+    width: 120px;
+    height: 90px;
     background: var(--bg-color);
     border-radius: var(--border-radius);
     overflow: hidden;
+    border: 2px solid transparent;
+    transition: all 0.3s ease;
+}
+
+.video-wrapper.current-turn {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 12px rgba(37, 99, 235, 0.5);
+}
+
+.video-wrapper.knocked {
+    border-color: var(--warning);
+    box-shadow: 0 0 12px rgba(245, 158, 11, 0.5);
 }
 
 .video-wrapper video {
@@ -323,6 +362,21 @@ input[type="text"]:focus {
     padding: 2px 8px;
     border-radius: 4px;
     font-size: 0.75rem;
+    max-width: calc(100% - 8px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.video-wrapper .player-coins {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: rgba(0,0,0,0.7);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.65rem;
+    color: var(--gold);
 }
 
 /* Game Section */
@@ -421,13 +475,26 @@ input[type="text"]:focus {
 /* Table Area */
 .table-area {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: 60px;
-    padding: 24px;
+    gap: 16px;
+    padding: 24px 40px;
     background: var(--table-green);
-    border-radius: 16px;
-    min-height: 180px;
+    border-radius: 24px;
+    min-height: 200px;
+    min-width: 280px;
+    box-shadow:
+        inset 0 0 60px rgba(0,0,0,0.3),
+        0 4px 20px rgba(0,0,0,0.4);
+    border: 4px solid #0d4420;
+}
+
+.table-area .cards-row {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 40px;
 }
 
 .deck-area, .discard-area {
@@ -1054,9 +1121,24 @@ input[type="text"]:focus {
 
 /* Responsive */
 @media (max-width: 768px) {
+    .table-container {
+        gap: 8px;
+    }
+
+    .table-middle-row {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .players-left,
+    .players-right {
+        flex-direction: row;
+        min-width: auto;
+    }
+
     .video-wrapper {
-        width: 120px;
-        height: 90px;
+        width: 100px;
+        height: 75px;
     }
 
     .card {
@@ -1096,8 +1178,13 @@ input[type="text"]:focus {
     }
 
     .table-area {
-        gap: 30px;
-        padding: 16px;
+        padding: 16px 20px;
+        min-width: auto;
+        min-height: 160px;
+    }
+
+    .table-area .cards-row {
+        gap: 20px;
     }
 
     .game-controls {

--- a/public/index.html
+++ b/public/index.html
@@ -70,18 +70,6 @@
             </div>
         </header>
 
-        <!-- Video Chat Section -->
-        <section class="video-section">
-            <div id="videos-container" class="videos-grid">
-                <!-- Local video -->
-                <div class="video-wrapper local">
-                    <video id="local-video" autoplay muted playsinline></video>
-                    <span class="player-name">Tu</span>
-                </div>
-                <!-- Remote videos will be added dynamically -->
-            </div>
-        </section>
-
         <!-- Game Section -->
         <section class="game-section">
             <!-- Turn indicator -->
@@ -90,25 +78,54 @@
                 <span id="knock-indicator" class="knock-indicator hidden">BUSSATA!</span>
             </div>
 
-            <!-- Players info bar -->
-            <div id="players-info" class="players-info"></div>
+            <!-- Table with players around it -->
+            <div class="table-container">
+                <!-- Top players (opponents) -->
+                <div id="players-top" class="players-position players-top"></div>
 
-            <!-- Table area -->
-            <div class="table-area">
-                <!-- Deck -->
-                <div class="deck-area">
-                    <div id="deck" class="card card-back">
-                        <span id="deck-count">52</span>
+                <!-- Middle row: left players, table, right players -->
+                <div class="table-middle-row">
+                    <!-- Left players -->
+                    <div id="players-left" class="players-position players-left"></div>
+
+                    <!-- Table area -->
+                    <div class="table-area">
+                        <!-- Cards row -->
+                        <div class="cards-row">
+                            <!-- Deck -->
+                            <div class="deck-area">
+                                <div id="deck" class="card card-back">
+                                    <span id="deck-count">52</span>
+                                </div>
+                                <span class="area-label">Mazzo</span>
+                            </div>
+
+                            <!-- Discard pile -->
+                            <div class="discard-area">
+                                <div id="discard-pile" class="discard-pile"></div>
+                                <span class="area-label">Pozzo</span>
+                            </div>
+                        </div>
+
+                        <!-- Players info (coins) displayed in table -->
+                        <div id="players-info" class="players-info"></div>
                     </div>
-                    <span class="area-label">Mazzo</span>
+
+                    <!-- Right players -->
+                    <div id="players-right" class="players-position players-right"></div>
                 </div>
 
-                <!-- Discard pile -->
-                <div class="discard-area">
-                    <div id="discard-pile" class="discard-pile"></div>
-                    <span class="area-label">Pozzo</span>
+                <!-- Bottom: local player -->
+                <div id="players-bottom" class="players-position players-bottom">
+                    <div class="video-wrapper local">
+                        <video id="local-video" autoplay muted playsinline></video>
+                        <span class="player-name">Tu</span>
+                    </div>
                 </div>
             </div>
+
+            <!-- Hidden container for legacy compatibility -->
+            <div id="videos-container" class="hidden"></div>
 
             <!-- Player's hand -->
             <div class="hand-area">


### PR DESCRIPTION
## Summary
- Redesigned game layout to position player videos around the central green table
- Local player appears at bottom, remote players at top/left/right sides
- Added visual feedback for current turn (blue border/glow) and knock status (orange border/glow)
- Enhanced table styling with inset shadow and border for more realistic feel

Closes #4

## Test plan
- [ ] Create a game room and verify local player video appears at bottom
- [ ] Join with 2-4 additional players and verify they appear at top/left/right
- [ ] Verify turn indicator highlights the correct player's video
- [ ] Verify knock status shows on the player who knocked
- [ ] Test responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)